### PR TITLE
when pull_request_review body: null, don't dm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-code-review",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "author": "Alley Interactive <ops+hubot@alleyinteractive.com>",
   "description": "A Hubot script for GitHub code review on Slack",
   "main": "index.coffee",

--- a/src/code-reviews.coffee
+++ b/src/code-reviews.coffee
@@ -313,11 +313,12 @@ module.exports = (robot) ->
           req.body.review.body
         )
       else
-        code_reviews.comment_cr_by_url(
-          req.body.pull_request.html_url,
-          req.body.review.user.login,
-          req.body.review.body
-        )
+        if req.body.review.body?
+          code_reviews.comment_cr_by_url(
+            req.body.pull_request.html_url,
+            req.body.review.user.login,
+            req.body.review.body
+          )
         response = "pull_request_review not yet approved #{req.body.pull_request.html_url}"
     else
       res.statusCode = 400


### PR DESCRIPTION
current GitHub implementation sends null body when commenting or replying to inline code comments:

{
  "action": "submitted",
  "review": {
    "id": 24110610,
    "user": {
      "login": "benpbolton",
...
    },
    "body": null,
    "commit_id": "4f2b2202d8fd89dc7424385e7d6d1fc5395dca98",
    "submitted_at": "2017-02-27T22:19:00Z",
    "state": "commented",

... so we'll skip sending a DM