### PR TITLE
Ignore submitter comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-code-review",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "author": "Alley Interactive <ops+hubot@alleyinteractive.com>",
   "description": "A Hubot script for GitHub code review on Slack",
   "main": "index.coffee",

--- a/src/CodeReview.coffee
+++ b/src/CodeReview.coffee
@@ -2,5 +2,6 @@ class CodeReview
   constructor: (@user, @slug, @url, @status = 'new', @reviewer = false) ->
     @last_updated = Date.now()
     @extra_info = ""
+    @github_pr_submitter = @user
 
 module.exports = CodeReview


### PR DESCRIPTION
Query github API for the PR (we already do this for the files) to grab the github account of the PR submitter... then keep any comments made by that submitter from being DM'd to the PR submitter in slack

[edit] This is cool