### PR TITLE
MOPS-724 close when changes_requested

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,11 +45,6 @@
         }
       }
     },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-    },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -1678,6 +1673,13 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
         "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        }
       }
     },
     "has-flag": {
@@ -3358,6 +3360,13 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        }
       }
     },
     "strip-bom": {

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   "dependencies": {
     "coffeescript": "^1.12.7",
     "githubot": "^1.0.1",
-    "moment": "^2.19.3",
-    "node-schedule": "^1.2.5",
     "hubot": "^2.19.0",
     "hubot-redis-brain": "^0.0.4",
+    "moment": "^2.19.3",
+    "node-schedule": "^1.2.5",
     "punycode": "^2.1.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-code-review",
-  "version": "0.6.5",
-  "author": "Alley Interactive <ops+hubot@alleyinteractive.com>",
+  "version": "0.6.6",
+  "author": "Alley Interactive <ops+hubot@alley.co>",
   "description": "A Hubot script for GitHub code review on Slack",
   "main": "index.coffee",
   "repository": {

--- a/src/CodeReviews.coffee
+++ b/src/CodeReviews.coffee
@@ -653,7 +653,7 @@ class CodeReviews
           # PR was closed before anyone claimed it
           newStatus = 'closed'
           message = "Hey @#{cr.user.name}, looks like the PR for *#{cr.slug}* has some" +
-          " (changes requested) on GitHub. I've removed `#{cr.slug}` from the queue," +
+          " changes requested on GitHub. I've removed `#{cr.slug}` from the queue," +
           " but you should add it back when you need another review."
 
         # update CR, send message to room, add to results

--- a/src/code-reviews.coffee
+++ b/src/code-reviews.coffee
@@ -255,8 +255,6 @@ module.exports = (robot) ->
       res.send 'x-github-event is required'
       return
 
-    console.log(req.body);
-
     # Check if PR was approved (via emoji in issue_comment body)
     if req.headers['x-github-event'] is 'issue_comment'
       if ((process.env.HUBOT_CODE_REVIEW_EMOJI_APPROVE?) and

--- a/src/code-reviews.coffee
+++ b/src/code-reviews.coffee
@@ -255,6 +255,8 @@ module.exports = (robot) ->
       res.send 'x-github-event is required'
       return
 
+    console.log(req.body);
+
     # Check if PR was approved (via emoji in issue_comment body)
     if req.headers['x-github-event'] is 'issue_comment'
       if ((process.env.HUBOT_CODE_REVIEW_EMOJI_APPROVE?) and

--- a/src/code-reviews.coffee
+++ b/src/code-reviews.coffee
@@ -288,7 +288,7 @@ module.exports = (robot) ->
       if req.body.action is 'closed'
         # update CRs
         status = if req.body.pull_request.merged then 'merged' else 'closed'
-        updated = code_reviews.handle_merge_close req.body.pull_request.html_url, status
+        updated = code_reviews.handle_close req.body.pull_request.html_url, status
         # build response message
         if updated.length
           response = "set status of #{updated[0].slug} to "
@@ -315,6 +315,21 @@ module.exports = (robot) ->
             req.body.pull_request.html_url,
             req.body.review.user.login,
             req.body.review.body
+          )
+        else if req.body.review.state is 'changes_requested'
+          response = "pull_request_review changes requested #{req.body.pull_request.html_url}"
+
+          # Send the changes requested comment to the submitter
+          if req.body.review.body?
+            code_reviews.comment_cr_by_url(
+              req.body.pull_request.html_url,
+              req.body.review.user.login,
+              req.body.review.body
+            )
+          # Close up the PR and notify the submitter to resubmit when changes are made
+          code_reviews.handle_close(
+            req.body.pull_request.html_url,
+            'changes_requested'
           )
         else
           response = "pull_request_review not yet approved #{req.body.pull_request.html_url}"


### PR DESCRIPTION
This more elegantly captures the anti-pattern:

1. Dev 1 submits code review in-channel
2. Dev 2 *without claiming the code review* completes a pull request review in GitHub and 'requests changes' (essentially rejects the code as it stands)

In the above scenario, hubot-code-review will now:

1. Send the `changes_requested` comment to Dev 1
2. Remove the PR from the room queue with the message:
> Hey @[user], looks like the PR for *[stub]* has some (changes requested) on GitHub. I've removed `[stub]` from the queue, but you should add it back when you need another review.
