### PR TITLE
Check if the commenter is a user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.log
 .DS_Store*
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "workbench.colorCustomizations": {
+    "activityBar.background": "#362C1E",
+    "titleBar.activeBackground": "#4B3D2A",
+    "titleBar.activeForeground": "#FBFAF8"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "workbench.colorCustomizations": {
-    "activityBar.background": "#362C1E",
-    "titleBar.activeBackground": "#4B3D2A",
-    "titleBar.activeForeground": "#FBFAF8"
-  }
-}

--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ file type lookups or DMs when your PR is approved/rejected require 2 things:
 - If ```HUBOT_GITHUB_TOKEN``` is set, Hubot can query the GitHub api for file type information on PR submission. Check out the instructions for configuring
 [`HUBOT_GITHUB_TOKEN` for hubot-code-review](/docs/HUBOT_GITHUB_TOKEN.md)
 
-- ```HUBOT_CODE_REVIEW_EMOJI_APPROVE``` an [Alley Interactive](https://www.alleyinteractive.com) cultural relic before the days GitHub incorporated [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/). If this variable is `true`, a comment on the PR that includes one or more emoji conveys PR approval
-and will DM the submitter accordingly.
+- ```HUBOT_CODE_REVIEW_EMOJI_APPROVE``` an [Alley Interactive](https://www.alleyinteractive.com) cultural relic before the days GitHub incorporated [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/). If this variable is `true`, a comment (excluding a `comment.user.type` of `Bot`) on the PR that includes one or more emoji conveys PR approval and will DM the submitter accordingly.
 
 - Set ```HUBOT_CODE_REVIEW_FILE_EXTENSIONS``` to a space separated list of file extensions (_default "coffee css html js jsx md php rb scss sh txt yml"_) to configure what file types you prefer to group together in the ```HUBOT_CODE_REVIEW_META``` information alongside the PR slug in channel. Note that this requires a [`HUBOT_GITHUB_TOKEN` for hubot-code-review](/docs/HUBOT_GITHUB_TOKEN.md)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-code-review",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-code-review",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "Alley Interactive <ops+hubot@alley.co>",
   "description": "A Hubot script for GitHub code review on Slack",
   "main": "index.coffee",

--- a/src/CodeReviews.coffee
+++ b/src/CodeReviews.coffee
@@ -389,7 +389,7 @@ class CodeReviews
         trigger = =>
           for room of @room_queues
             if room in valid_rooms or
-            robot.adapterName isnt "slack"
+            @robot.adapterName isnt "slack"
               active_crs = @list room
               if active_crs["cr"].length > 0
                 rooms_have_new_crs = true
@@ -403,7 +403,7 @@ class CodeReviews
                   @robot.send { room: room }, "This is an hourly reminder."
             else
               # If room doesn't exist, clear out the queue for it
-              @robot.logger.warning "Unable to find room #{roomName}; removing from room_queue"
+              @robot.logger.warning "Unable to find room #{room}; removing from room_queue"
               delete @room_queues[room]
               @update_redis()
 

--- a/src/code-reviews.coffee
+++ b/src/code-reviews.coffee
@@ -271,7 +271,7 @@ module.exports = (robot) ->
       process.env.HUBOT_CODE_REVIEW_EMOJI_APPROVE)
         if (code_reviews.emoji_regex.test(req.body.comment.body) or
         code_reviews.emoji_unicode_test(req.body.comment.body)) and
-        req.body.comment.user.type == 'User'
+        req.body.comment.user.type != 'Bot'
           code_reviews.approve_cr_by_url(
             req.body.issue.html_url,
             req.body.comment.user.login,

--- a/src/code-reviews.coffee
+++ b/src/code-reviews.coffee
@@ -269,8 +269,9 @@ module.exports = (robot) ->
     if req.headers['x-github-event'] is 'issue_comment'
       if ((process.env.HUBOT_CODE_REVIEW_EMOJI_APPROVE?) and
       process.env.HUBOT_CODE_REVIEW_EMOJI_APPROVE)
-        if code_reviews.emoji_regex.test(req.body.comment.body) or
-        code_reviews.emoji_unicode_test(req.body.comment.body)
+        if (code_reviews.emoji_regex.test(req.body.comment.body) or
+        code_reviews.emoji_unicode_test(req.body.comment.body)) and
+        req.body.comment.user.type == 'User'
           code_reviews.approve_cr_by_url(
             req.body.issue.html_url,
             req.body.comment.user.login,


### PR DESCRIPTION
Fixes #43 

If I'm reading https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#issue_comment correctly this should properly check if the commenter is a `User`. Here's the API payload for a bot: https://api.github.com/users/netlify[bot]