### PR TITLE
Send notifications to DM instead of code review channels

### DIFF
--- a/src/CodeReviews.coffee
+++ b/src/CodeReviews.coffee
@@ -141,7 +141,7 @@ class CodeReviews
     attachments.push
       fallback: "#{cr.url} could use your :eyes: Remember to claim it in ##{origin_room}"
       text: "*<#{cr.url}|#{cr.slug}>* could use your :eyes: Remember to claim it" +
-      " in <https://alleyinteractive.slack.com/archives/#{origin_room}|##{origin_room}>"
+      " in <https://slack.com/app_redirect?channel=#{origin_room}|##{origin_room}>"
       mrkdwn_in: ["text"]
       color: "#575757"
     sendFancyMessage @robot, channel_to_notify, attachments

--- a/src/CodeReviews.coffee
+++ b/src/CodeReviews.coffee
@@ -689,9 +689,11 @@ class CodeReviews
         else if status is "changes_requested"
           # PR was reviewed with changes_requested before anyone claimed it in-channel
           newStatus = 'closed'
-          message = "Hey @#{cr.user.name}, looks like the PR for *#{cr.slug}* has some" +
-          " changes requested on GitHub. I've removed `#{cr.slug}` from the queue,  but you" +
-          " should add it back with a `hubot reset #{cr.slug}` when you need another review."
+          message = "Hey @#{cr.user.name}, looks like the PR for *#{cr.slug}* over in" +
+          " <https://slack.com/app_redirect?channel=#{room}|##{room}> has some changes" +
+          " requested on GitHub. I've removed `#{cr.slug}` from the queue,  but you should" +
+          " add it back with a `hubot reset #{cr.slug}` when you need another review."
+          console.log(message)
           messageReceiver = cr.user.name
 
         # update CR, send message to room, add to results

--- a/src/CodeReviews.coffee
+++ b/src/CodeReviews.coffee
@@ -593,7 +593,7 @@ class CodeReviews
   #
   # @param string url URL of PR on GitHub
   # @param string commenter GitHub username of person who approved
-  # @param string string comment Full text of comment
+  # @param string comment Full text of comment
   # @return none
   comment_cr_by_url: (url, commenter, comment) ->
     cr_list = @update_cr_by_url url
@@ -654,6 +654,7 @@ class CodeReviews
       i = @find_slug_index room, slug
       unless i == false
         cr = @room_queues[room][i]
+        messageReceiver = cr.reviewer
         # Handle merged
         if status is "merged"
           switch cr.status
@@ -676,6 +677,7 @@ class CodeReviews
               newStatus = false
               message = "Hey @#{cr.user.name}, looks like *#{cr.slug}* was closed on GitHub." +
               " Say `ignore #{cr.slug}` to remove it from the queue."
+              messageReceiver = cr.user.name
             # PR was closed after someone claimed it but before it was approved
             when "claimed"
               newStatus = false
@@ -690,12 +692,13 @@ class CodeReviews
           message = "Hey @#{cr.user.name}, looks like the PR for *#{cr.slug}* has some" +
           " changes requested on GitHub. I've removed `#{cr.slug}` from the queue,  but you" +
           " should add it back with a `hubot reset #{cr.slug}` when you need another review."
+          messageReceiver = cr.user.name
 
         # update CR, send message to room, add to results
         if newStatus
           @update_cr @room_queues[room][i], newStatus
         if message
-          @robot.messageRoom room, message
+          @robot.messageRoom '@' + messageReceiver, message
         crs_found.push @room_queues[room][i]
     # return results
     return crs_found

--- a/test/codeReviewSpec.js
+++ b/test/codeReviewSpec.js
@@ -822,7 +822,7 @@ describe('Code Review', () => {
   it('does not update a new PR to merged', (done) => {
     adapter.on('send', (envelope, strings) => {
       expect(strings[0]).toBe('*special/456* has been merged but still needs to be reviewed, just fyi.');
-      expect(envelope.room).toBe('test_room');
+      expect(envelope.room).toBe('@jaredcobb');
       done();
     });
     testMergeClose('merged', 'new', 'new');
@@ -831,7 +831,7 @@ describe('Code Review', () => {
   it('does not update a claimed PR to merged', (done) => {
     adapter.on('send', (envelope, strings) => {
       expect(strings[0]).toBe('Hey @jaredcobb, *special/456* has been merged but you should keep reviewing.');
-      expect(envelope.room).toBe('test_room');
+      expect(envelope.room).toBe('@jaredcobb');
       done();
     });
     testMergeClose('merged', 'claimed', 'claimed');
@@ -840,7 +840,7 @@ describe('Code Review', () => {
   it('does not update a new PR to closed', (done) => {
     adapter.on('send', (envelope, strings) => {
       expect(strings[0]).toMatch(/Hey @(\w+), looks like \*special\/456\* was closed on GitHub\. Say `ignore special\/456` to remove it from the queue\./i);
-      expect(envelope.room).toBe('test_room');
+      expect(envelope.room).toMatch(/@(\w+)/i);
       done();
     });
     testMergeClose('closed', 'new', 'new');
@@ -849,7 +849,7 @@ describe('Code Review', () => {
   it('does not update a claimed PR to closed', (done) => {
     adapter.on('send', (envelope, strings) => {
       expect(strings[0]).toMatch(/Hey @jaredcobb, \*special\/456\* was closed on GitHub\. Maybe ask @(\w+) if it still needs to be reviewed\./i);
-      expect(envelope.room).toBe('test_room');
+      expect(envelope.room).toBe('@jaredcobb');
       done();
     });
     testMergeClose('closed', 'claimed', 'claimed');


### PR DESCRIPTION
Something we had discussed in Tech CoP Planning was removing the alert that is sent to #codereview when changes are requested. This PR is an attempt at starting that process.

# Reasoning
What this PR does is remove all public messages to the channel, instead directing the generic message to the correct recipient--either the reviewer, or the submitter. The reasoning for this is simple: They were already the intended recipient of the message. The message they receive asks them to perform optional tasks, which are unlikely to be performed by anybody else on staff even if they do happen to see the message.

Due to this, it is my belief that very little will change in workflow with this change, except the removal of what can sometimes feel like an unintentional public shaming when we request changes. The hope is that this will lead to reviewers feeling more comfortable with using this option.