### PR TITLE
Hotfix: Fix channel mentions with Slack forced IDs

### DIFF
--- a/src/CodeReviews.coffee
+++ b/src/CodeReviews.coffee
@@ -477,8 +477,12 @@ class CodeReviews
 
     # If our submitter provided a notification individual/channel, say so.
     if (notify_name)?
+      if notify_name.match(/^#/) # It's a channel, wrap as a link
+        notify_link = "<#{notify_name}|>"
+
       msg.send "*#{cr.slug}* is now in the code review queue," +
-      " and #{notify_name} has been notified."
+      " and #{notify_link || notify_name} has been notified."
+
     else
       msg.send "*#{cr.slug}* is now in the code review queue." +
       " Let me know if anyone starts reviewing this."

--- a/src/CodeReviews.coffee
+++ b/src/CodeReviews.coffee
@@ -20,7 +20,7 @@ class CodeReviews
       if matches
         @github_url = matches[0]
     @pr_url_regex = ///
-      ^(https?:\/\/#{@github_url}\/([^\/]+)\/([^\/]+)\/pull\/(\d+))(?:\/files)?\/?(\s+[#|@]?[0-9a-z_-]+)?\s*$
+      ^(https?:\/\/#{@github_url}\/([^\/]+)\/([^\/]+)\/pull\/(\d+))(?:\/files)?\/?(?:\s+<?([#|@]?[0-9a-z_-]+)(?:\|>)?)?\s*$
     ///i
     @room_queues = {}
     @current_timeout = null

--- a/src/lib/sendFancyMessage.coffee
+++ b/src/lib/sendFancyMessage.coffee
@@ -10,22 +10,24 @@ module.exports = (robot, room, attachments, text) ->
       fallback_text += "\n#{attachment.fallback}"
     robot.messageRoom room, fallback_text.replace(/\n$/, "")
   else
+    # Strip any preceeding # from room name
+    room_name = room.replace /^#/g, ""
     # Working around a Slack for Android bug 2016-08-30 by supplying
     # text attribute outside of attachment array to allow previews
     if text?
       try
-        robot.send { room: room },
+        robot.send { room: room_name },
           as_user: true
-          channel: room
+          channel: room_name
           text: text
           attachments: attachments
       catch sendErr
         robot.logger.error "Unable to send message to room: #{room}: ", sendErr, attachments
     else
       try
-        robot.send { room: room },
+        robot.send { room: room_name },
           as_user: true
-          channel: room
+          channel: room_name
           attachments: attachments
       catch sendErr
         robot.logger.error "Unable to send message to room: #{room}: ", sendErr, attachments


### PR DESCRIPTION
Starting yesterday(?), Slack started passing along all references to other room names as internal links (so `#my_channel` is reported to hubot as `<#C000000|>` or similar).

This will fix the regex to 'hear' those IDs and notify accordingly when the user specifies a notification option after the PR like

> https://github.com/alleyinteractive/hubot-code-review/pull/52 #my_channel