### PR TITLE
fix: use auth header instead of token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hubot-code-review",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hubot-code-review",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "GPL-3.0",
       "dependencies": {
         "coffeescript": "^1.12.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-code-review",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": "Alley Interactive <ops+hubot@alley.co>",
   "description": "A Hubot script for GitHub code review on Slack",
   "main": "index.coffee",

--- a/src/lib/msgRoomName.coffee
+++ b/src/lib/msgRoomName.coffee
@@ -6,9 +6,9 @@ module.exports = (msg, next) ->
   if msg.robot.adapterName is "slack"
     msg.robot.http("https://slack.com/api/conversations.info")
       .query({
-        token: process.env.HUBOT_SLACK_TOKEN
         channel: msg.message.room
       })
+      .header('Authorization', 'Bearer ' + process.env.HUBOT_SLACK_TOKEN )
       .get() (err, response, body) ->
         channel = JSON.parse(body)
         next channel.channel.name


### PR DESCRIPTION
👋 howdy Alley team! We are implementing `hubot-code-review` and ran into an issue with the token query parameter. I believe it is due to this change in 2021 – https://api.slack.com/changelog/2020-11-no-more-tokens-in-querystrings-for-newly-created-apps

For future compatibility, we would like to propose the following change.

We have tested this on our Hubot implementation and are currently using the patched version in our Slack instance.