### PR TITLE
13836: [hubot-code-review] Channel ghosts

### DIFF
--- a/src/CodeReviews.coffee
+++ b/src/CodeReviews.coffee
@@ -475,7 +475,8 @@ class CodeReviews
       notify_name = notification_string[0...] || null
     if (notify_name)?
       msgRoomName msg, (room_name) =>
-        @notify_channel(cr, room_name, notify_name)
+        if room_name
+          @notify_channel(cr, room_name, notify_name)
 
     # If our submitter provided a notification individual/channel, say so.
     if (notify_name)?

--- a/src/lib/msgRoomName.coffee
+++ b/src/lib/msgRoomName.coffee
@@ -1,16 +1,26 @@
 # Return the human-readable name of the channel the msg was sent in
 # for hubot-slack's breaking change from 3->4 of using ID instead of name
 # @param  {msg Object}
+# @param  {next Function} callback
+# @param  {retryCount Number} number of times this function has been retried
 # @return String human-readable name of the channel
-module.exports = (msg, next) ->
+module.exports = (msg, next, retryCount = 0) ->
   if msg.robot.adapterName is "slack"
     msg.robot.http("https://slack.com/api/conversations.info")
       .query({
         channel: msg.message.room
       })
-      .header('Authorization', 'Bearer ' + process.env.HUBOT_SLACK_TOKEN )
+      .header('Authorization', 'Bearer ' + process.env.HUBOT_SLACK_TOKEN)
       .get() (err, response, body) ->
-        channel = JSON.parse(body)
-        next channel.channel.name
+        if err || response.ok is false || !response.channel
+          if retryCount < 3 # Retry up to 3 times
+            console.warn "Retrying to get channel info for #{msg.message.room}"
+            console.warn "[Attempt #{retryCount+ 1}]"
+            module.exports(msg, next, retryCount + 1)
+          else
+            console.error "Failed to get channel name after retries for #{msg.message.room}"
+            next null # Signal failure after retries
+        else
+          next response.channel.name
   else
     next msg.message.room

--- a/src/lib/msgRoomName.coffee
+++ b/src/lib/msgRoomName.coffee
@@ -12,15 +12,18 @@ module.exports = (msg, next, retryCount = 0) ->
       })
       .header('Authorization', 'Bearer ' + process.env.HUBOT_SLACK_TOKEN)
       .get() (err, response, body) ->
-        if err || response.ok is false || !response.channel
+        body = JSON.parse(body) if body
+        if err || response.statusCode isnt 200 || !body?.channel
           if retryCount < 3 # Retry up to 3 times
-            console.warn "Retrying to get channel info for #{msg.message.room}"
-            console.warn "[Attempt #{retryCount+ 1}]"
-            module.exports(msg, next, retryCount + 1)
+            console.warn "Retry [#{retryCount + 1}] to get channel info for #{msg.message.room}"
+            # Retry after 1 second
+            setTimeout (-> module.exports(msg, next, retryCount + 1)), 1000
           else
-            console.error "Failed to get channel name after retries for #{msg.message.room}"
+            error = err || (body)?.error
+            console.error "Failed to get channel name after #{retryCount} retries for " + \
+            "#{msg.message.room}. Status: #{response.statusCode}, Error: #{error}"
             next null # Signal failure after retries
         else
-          next response.channel.name
+          next body.channel.name
   else
     next msg.message.room


### PR DESCRIPTION
## Summary

This PR aims to resolve the issue of code reviews being parroted and unclaimable in channels they weren't added to, causing confusion and frustration for users. The solution involves making the `msgRoomName` call more robust and verbose to ensure proper room name matching.

## Notes for reviewers

This issue is particularly obtuse and has been difficult to pin down. It is seemingly caused when we're unable to get or match a human-readable room name (via `msgRoomName`) so this solution attempts to make that call a bit more robust and verbose.

## Changelog entries

### Added

### Changed

- Improved `msgRoomName` call for better room name matching

### Deprecated

### Removed

### Fixed

- Prevent code reviews from being parroted and unclaimable in unrelated channels

### Security

## Ticket(s)

- [#13836](https://getscrum.app/teams/1/stories/13836)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a retry mechanism for fetching channel information, improving reliability.
- **Bug Fixes**
	- Enhanced error handling and messaging for room-specific actions.
	- Ensured actions are only performed when room name is available, preventing potential errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->