### PR TITLE
13915: Follow up to [hubot-code-review] channel ghosts

### DIFF
--- a/src/CodeReview.coffee
+++ b/src/CodeReview.coffee
@@ -1,5 +1,12 @@
 class CodeReview
-  constructor: (@user, @slug, @url, @status = 'new', @reviewer = false) ->
+  constructor: (
+  @user,
+  @slug,
+  @url,
+  @room = @user.room,
+  @channel_id = @user.room,
+  @status = 'new',
+  @reviewer = false) ->
     @last_updated = Date.now()
     @extra_info = ""
     @github_pr_submitter = @user

--- a/src/CodeReviews.coffee
+++ b/src/CodeReviews.coffee
@@ -178,7 +178,7 @@ class CodeReviews
   # Add a CR to a room queue
   #
   # @param CodeReview cr Code Review object to add
-  # @retun none
+  # @return none
   add: (cr) ->
     return unless cr.room
     @room_queues[cr.room] ||= []

--- a/src/CodeReviews.coffee
+++ b/src/CodeReviews.coffee
@@ -180,9 +180,9 @@ class CodeReviews
   # @param CodeReview cr Code Review object to add
   # @retun none
   add: (cr) ->
-    return unless cr.user.room
-    @room_queues[cr.user.room] ||= []
-    @room_queues[cr.user.room].unshift(cr) if false == @find_slug_index(cr.user.room, cr.slug)
+    return unless cr.room
+    @room_queues[cr.room] ||= []
+    @room_queues[cr.room].unshift(cr) if false == @find_slug_index(cr.room, cr.slug)
     @update_redis()
     @reminder_count = 0
     @queue()

--- a/src/code-reviews.coffee
+++ b/src/code-reviews.coffee
@@ -290,7 +290,7 @@ module.exports = (robot) ->
       if ((process.env.HUBOT_CODE_REVIEW_EMOJI_APPROVE?) and
       process.env.HUBOT_CODE_REVIEW_EMOJI_APPROVE)
         if (code_reviews.emoji_regex.test(req.body.comment.body) or
-        code_reviews.emoji_unicode_test(req.body.comment.body)) and
+        code_reviews.emoji_unicode_test(req.body.comment.body))
           code_reviews.approve_cr_by_url(
             req.body.issue.html_url,
             req.body.comment.user.login,

--- a/src/code-reviews.coffee
+++ b/src/code-reviews.coffee
@@ -287,12 +287,12 @@ module.exports = (robot) ->
       return
 
     # Check if PR was approved (via emoji in issue_comment body)
-    if req.headers['x-github-event'] is 'issue_comment'
+    if req.headers['x-github-event'] is 'issue_comment' and
+    req.body.comment.user.type != 'Bot' # Commenter is not a bot
       if ((process.env.HUBOT_CODE_REVIEW_EMOJI_APPROVE?) and
       process.env.HUBOT_CODE_REVIEW_EMOJI_APPROVE)
         if (code_reviews.emoji_regex.test(req.body.comment.body) or
         code_reviews.emoji_unicode_test(req.body.comment.body)) and
-        req.body.comment.user.type != 'Bot'
           code_reviews.approve_cr_by_url(
             req.body.issue.html_url,
             req.body.comment.user.login,
@@ -331,7 +331,8 @@ module.exports = (robot) ->
         response = "#{req.body.pull_request.html_url} is still open"
 
     # Check if PR was approved via GitHub's Pull Request Review
-    else if req.headers['x-github-event'] is 'pull_request_review'
+    else if req.headers['x-github-event'] is 'pull_request_review' and
+    req.body.review.user.type != 'Bot' # not a bot
       if req.body.action? and req.body.action is 'dismissed'
         response = "pull_request_review dismissed #{req.body.pull_request.html_url}"
         code_reviews.dismiss_cr_by_url(

--- a/src/code-reviews.coffee
+++ b/src/code-reviews.coffee
@@ -25,9 +25,7 @@ module.exports = (robot) ->
     slug = code_reviews.matches_to_slug msg.match
     msgRoomName msg, (room_name) ->
       if slug and room_name
-        cr = new CodeReview msg.message.user, slug, url
-        # Specific override for human readable room name
-        cr.user.room = room_name
+        cr = new CodeReview msg.message.user, slug, url, room_name, msg.message.room
         found = code_reviews.find_slug_index room_name, slug
         if found is false
           # 'Take' a code review for karma
@@ -323,7 +321,7 @@ module.exports = (robot) ->
         if updated.length
           response = "set status of #{updated[0].slug} to "
           rooms = for cr in updated
-            "#{cr.status} in #{cr.user.room}"
+            "#{cr.status} in #{cr.room}"
           response += rooms.join(', ')
         else
           response = "#{req.body.pull_request.html_url} not found in any queue"

--- a/test/codeReviewEmojiAcceptSpec.js
+++ b/test/codeReviewEmojiAcceptSpec.js
@@ -271,7 +271,7 @@ describe('Code Review Emoji Approval', () => {
         submitter[key] = userMeta[key];
       });
     }
-    code_reviews.add(new CodeReview(submitter, makeSlug(url), url));
+    code_reviews.add(new CodeReview(submitter, makeSlug(url), url), submitter.room, submitter.room);
   }
 
   /**

--- a/test/codeReviewSpec.js
+++ b/test/codeReviewSpec.js
@@ -118,7 +118,8 @@ describe('Code Review', () => {
       // there should now be one room from the current user
       const rooms = Object.keys(code_reviews.room_queues);
       expect(rooms.length).toEqual(1);
-      expect(rooms[0]).toEqual(currentUser.room);
+      expect(rooms[0]).toEqual(code_reviews.room_queues[rooms[0]][0].room);
+      expect(rooms[0]).toEqual(code_reviews.room_queues[rooms[0]][0].channel_id);
 
       // there should be one CR in the room queue
       expect(code_reviews.room_queues[rooms[0]].length).toEqual(1);
@@ -136,7 +137,7 @@ describe('Code Review', () => {
   it('will not a allow the same CR in the same room regardless of status', (done) => {
     const currentUser = users[7];
     const url = PullRequests[4];
-    code_reviews.add(new CodeReview(currentUser, makeSlug(url), url));
+    code_reviews.add(new CodeReview(currentUser, makeSlug(url), url, currentUser.room, currentUser.room));
 
     // listener for second time the CR is added
     adapter.on('send', (envelope, strings) => {
@@ -163,7 +164,7 @@ describe('Code Review', () => {
     const currentUser = users[12];
     const url = PullRequests[6];
     const firstRoom = currentUser.room;
-    code_reviews.add(new CodeReview(currentUser, makeSlug(url), url));
+    code_reviews.add(new CodeReview(currentUser, makeSlug(url), url, firstRoom, firstRoom));
 
     // listener for second time the CR is added
     adapter.on('send', (envelope, strings) => {
@@ -358,8 +359,8 @@ describe('Code Review', () => {
     code_reviews.room_queues.test_room = [];
     code_reviews.room_queues.second_room = [];
     PullRequests.forEach((url, i) => {
-      const cr = new CodeReview(users[6], makeSlug(url), url);
       const room = 3 >= i ? 'test_room' : 'second_room';
+      const cr = new CodeReview(users[6], makeSlug(url), url, room, room);
       code_reviews.room_queues[room].unshift(cr);
     });
     expect(roomStatusCount('test_room', 'new')).toBe(4);
@@ -629,7 +630,7 @@ describe('Code Review', () => {
     const halfHourInMs = 1000 * 60 * 30;
     // add CRs with different ages and statuses
     statuses.forEach((status, i) => {
-      const cr = new CodeReview(users[i], makeSlug(PullRequests[i]), PullRequests[i]);
+      const cr = new CodeReview(users[i], makeSlug(PullRequests[i]), PullRequests[i], users[i].room, users[i].room);
       cr.status = status;
       cr.last_updated += -1 * i * halfHourInMs;
       code_reviews.add(cr);
@@ -990,7 +991,7 @@ describe('Code Review', () => {
         submitter[key] = userMeta[key];
       });
     }
-    code_reviews.add(new CodeReview(submitter, makeSlug(url), url));
+    code_reviews.add(new CodeReview(submitter, makeSlug(url), url, submitter.room, submitter.room));
   }
 
   /**


### PR DESCRIPTION
## Summary

Follow up to [hubot-code-review] channel ghosts (#13915)

This PR aims to address the channel ghost issue with hubot-code-review by storing room & channel_id directly. It also supresses comments and reviews from bots.

## Notes for reviewers

None.

## Changelog entries

### Added

### Changed

- Suppress comments and reviews from bots
- CodeReview stores room & channel_id directly
- Remove trailing and

### Deprecated

### Removed

### Fixed

- Experiment with alternate options to short-circuit channel ghost issue

### Security

## Ticket(s)

- [#13915](https://getscrum.app/teams/1/stories/13915)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved readability of the `CodeReview` class constructor.
  - Streamlined room data handling in the `CodeReviews` class.
  - Enhanced conditions to exclude bot actions in code review processes.

- **Bug Fixes**
  - Fixed room-related parameters in code review addition logic.

- **Tests**
  - Updated test cases to reflect new room parameter requirements in code review methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->